### PR TITLE
fix reset-password module import

### DIFF
--- a/src/app/pages/reset-password/reset-password.module.ts
+++ b/src/app/pages/reset-password/reset-password.module.ts
@@ -6,7 +6,7 @@ import { Routes, RouterModule } from '@angular/router';
 import { IonicModule } from '@ionic/angular';
 
 import { ResetPasswordPage } from './reset-password.page';
-import { AuthModule } from 'src/app/shared-modules/auth.module';
+import { AuthModule } from '../../shared-modules/auth.module';
 
 const routes: Routes = [
   {


### PR DESCRIPTION
Otherwise, it won’t build successfully. Here’s the error message:

> ng run app:serve --host=localhost --port=8101
[ng] ℹ ｢wds｣: Project is running at http://localhost:8101/webpack-dev-server/
[ng] ℹ ｢wds｣: webpack output is served from /
[ng] ℹ ｢wds｣: 404s will fallback to //index.html
[ng] chunk {main} main.js, main.js.map (main) 2.13 kB [initial] [rendered]
[ng] chunk {polyfills} polyfills.js, polyfills.js.map (polyfills) 149 kB [initial] [rendered]
[ng] chunk {runtime} runtime.js, runtime.js.map (runtime) 6.09 kB [entry] [rendered]
[ng] chunk {styles} styles.js, styles.js.map (styles) 108 kB [initial] [rendered]
[ng] chunk {vendor} vendor.js, vendor.js.map (vendor) 339 kB [initial] [rendered]
[ng] Date: 2019-07-31T15:09:19.258Z - Hash: ec3cc6075c73a1058f96 - Time: 3761ms
[ng]
[ng] ERROR in No NgModule metadata found for 'REsetPasswordPageModule'.